### PR TITLE
Prevented blocking getch call on Windows

### DIFF
--- a/pytermgui/input.py
+++ b/pytermgui/input.py
@@ -132,6 +132,9 @@ class _GetchWindows:
 
         # We need to type: ignore these on non-windows machines,
         # as the library does not exist.
+        if not msvcrt.kbhit():
+            # Return empty string if there is no input to get
+            return str()
         char = msvcrt.getch()  # type: ignore
         if char == b"\xe0":
             char = "\x1b"


### PR DESCRIPTION
Check msvcrt.kbhit() before attempting to get characters from stdin.
If there are no characters available, simply return an empty string.

Fixes #42